### PR TITLE
Bugfix/remove install script after success

### DIFF
--- a/Install_SindenLightgunDriver.sh
+++ b/Install_SindenLightgunDriver.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Exit immediately if a command exits with a non-zero status
+set -e
+
 # Define the path for Sinden scripts
 SINDEN_SCRIPTS_PATH="/media/fat/Scripts/Sinden"
 
@@ -16,7 +19,7 @@ mkdir -p $SINDEN_SCRIPTS_PATH
 cd $SINDEN_SCRIPTS_PATH
 
 # Download Sinden files on MiSTer using MrFusion 2.7
-wget -O main.zip https://github.com/MrLightgun/MiSTerSindenDriver/archive/refs/heads/main.zip
+wget -O main.zip https://github.com/Matt-Retrogamer/MiSTerSindenDriver/archive/refs/heads/main.zip
 unzip -o main.zip
 
 # Navigate to the downloaded directory
@@ -24,3 +27,21 @@ cd MiSTerSindenDriver-main
 
 echo "Starting MiSTerSindenDriver setup."
 ./Setup_SindenLightgunDriver.sh
+echo "Finished MiSTerSindenDriver setup."
+
+# Delete the first install Install_SindenLightgunDriver.sh file
+if [ -f "/media/fat/Scripts/Install_SindenLightgunDriver.sh" ]; then
+    echo "Deleting Install_SindenLightgunDriver.sh..."
+    rm -f /media/fat/Scripts/Install_SindenLightgunDriver.sh
+fi
+
+# Ask the user if they want to reboot the machine
+read -p "Install Successful. Do you want to reboot the machine? (Y/N): " -n 1 -r
+echo    # move to a new line
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+    echo "Rebooting the machine..."
+    reboot
+else
+    echo "Reboot cancelled. Script completed successfully."
+fi

--- a/Install_SindenLightgunDriver.sh
+++ b/Install_SindenLightgunDriver.sh
@@ -18,8 +18,10 @@ fi
 mkdir -p $SINDEN_SCRIPTS_PATH
 cd $SINDEN_SCRIPTS_PATH
 
+# Inform the user to wait until the download is done
+echo "Please wait while the latest version is being downloaded..."
 # Download Sinden files on MiSTer using MrFusion 2.7
-wget -O main.zip https://github.com/Matt-Retrogamer/MiSTerSindenDriver/archive/refs/heads/main.zip
+wget -q -O main.zip https://github.com/Matt-Retrogamer/MiSTerSindenDriver/archive/refs/heads/main.zip
 
 # Inform the user to wait until the unzip is done
 echo "Please wait while the files are being unzipped..."
@@ -38,13 +40,5 @@ if [ -f "/media/fat/Scripts/Install_SindenLightgunDriver.sh" ]; then
     rm -f /media/fat/Scripts/Install_SindenLightgunDriver.sh
 fi
 
-# Ask the user if they want to reboot the machine
-read -p "Install Successful. Do you want to reboot the machine? (Y/N): " -n 1 -r </dev/tty
-echo    # move to a new line
-if [[ $REPLY =~ ^[Yy]$ ]]
-then
-    echo "Rebooting the machine..."
-    reboot
-else
-    echo "Reboot cancelled. Script completed successfully."
-fi
+# Print success message asking the user to reboot the machine
+echo "Install Successful. Please reboot your MiSTer to complete the installation."

--- a/Install_SindenLightgunDriver.sh
+++ b/Install_SindenLightgunDriver.sh
@@ -49,7 +49,7 @@ fi
 
 # Delete the downloaded main.zip file
 if [ -f "$SINDEN_SCRIPTS_PATH/main.zip" ]; then
-    echo "Deleting Sinden/main.zip..."
+    echo "Deleting downloaded main.zip..."
     rm -f $SINDEN_SCRIPTS_PATH/main.zip
 fi
 

--- a/Install_SindenLightgunDriver.sh
+++ b/Install_SindenLightgunDriver.sh
@@ -20,7 +20,10 @@ cd $SINDEN_SCRIPTS_PATH
 
 # Download Sinden files on MiSTer using MrFusion 2.7
 wget -O main.zip https://github.com/Matt-Retrogamer/MiSTerSindenDriver/archive/refs/heads/main.zip
-unzip -o main.zip
+
+# Inform the user to wait until the unzip is done
+echo "Please wait while the files are being unzipped..."
+unzip -oq main.zip
 
 # Navigate to the downloaded directory
 cd MiSTerSindenDriver-main
@@ -36,7 +39,7 @@ if [ -f "/media/fat/Scripts/Install_SindenLightgunDriver.sh" ]; then
 fi
 
 # Ask the user if they want to reboot the machine
-read -p "Install Successful. Do you want to reboot the machine? (Y/N): " -n 1 -r
+read -p "Install Successful. Do you want to reboot the machine? (Y/N): " -n 1 -r </dev/tty
 echo    # move to a new line
 if [[ $REPLY =~ ^[Yy]$ ]]
 then

--- a/Install_SindenLightgunDriver.sh
+++ b/Install_SindenLightgunDriver.sh
@@ -21,17 +21,18 @@ cd $SINDEN_SCRIPTS_PATH
 # Inform the user to wait until the download is done
 echo "Please wait while the latest version is being downloaded..."
 # Download Sinden files on MiSTer using MrFusion 2.7
-wget -q -O main.zip https://github.com/Matt-Retrogamer/MiSTerSindenDriver/archive/refs/heads/main.zip
+wget -O main.zip https://github.com/Matt-Retrogamer/MiSTerSindenDriver/archive/refs/heads/main.zip
 
 # Inform the user to wait until the unzip is done
 echo "Please wait while the files are being unzipped..."
 unzip -oq main.zip
+echo "Files have been unzipped."
 
 # Navigate to the downloaded directory
 cd MiSTerSindenDriver-main
 
 echo "Starting MiSTerSindenDriver setup."
-./Setup_SindenLightgunDriver.sh
+source ./Setup_SindenLightgunDriver.sh
 echo "Finished MiSTerSindenDriver setup."
 
 # Delete the first install Install_SindenLightgunDriver.sh file
@@ -40,5 +41,5 @@ if [ -f "/media/fat/Scripts/Install_SindenLightgunDriver.sh" ]; then
     rm -f /media/fat/Scripts/Install_SindenLightgunDriver.sh
 fi
 
-# Print success message asking the user to reboot the machine
+# Print success message asking the user to reboot your MiSTer
 echo "Install Successful. Please reboot your MiSTer to complete the installation."

--- a/Install_SindenLightgunDriver.sh
+++ b/Install_SindenLightgunDriver.sh
@@ -14,6 +14,12 @@ if [ -d "/media/fat/Lightgun" ]; then
     rm -rf /media/fat/Lightgun
 fi
 
+# Remove deprecated SindenLightgun folder if it exists
+if [ -d "/media/fat/SindenLightgun" ]; then
+    echo "/media/fat/SindenLightgun folder found. Deleting..."
+    rm -rf /media/fat/SindenLightgun
+fi
+
 # Create and navigate to the Sinden directory
 mkdir -p $SINDEN_SCRIPTS_PATH
 cd $SINDEN_SCRIPTS_PATH
@@ -39,6 +45,12 @@ echo "Finished MiSTerSindenDriver setup."
 if [ -f "/media/fat/Scripts/Install_SindenLightgunDriver.sh" ]; then
     echo "Deleting Install_SindenLightgunDriver.sh..."
     rm -f /media/fat/Scripts/Install_SindenLightgunDriver.sh
+fi
+
+# Delete the downloaded main.zip file
+if [ -f "$SINDEN_SCRIPTS_PATH/main.zip" ]; then
+    echo "Deleting Sinden/main.zip..."
+    rm -f $SINDEN_SCRIPTS_PATH/main.zip
 fi
 
 # Print success message and inform the user about the reboot

--- a/Install_SindenLightgunDriver.sh
+++ b/Install_SindenLightgunDriver.sh
@@ -41,5 +41,8 @@ if [ -f "/media/fat/Scripts/Install_SindenLightgunDriver.sh" ]; then
     rm -f /media/fat/Scripts/Install_SindenLightgunDriver.sh
 fi
 
-# Print success message asking the user to reboot your MiSTer
-echo "Install Successful. Please reboot your MiSTer to complete the installation."
+# Print success message and inform the user about the reboot
+echo "Install Successful.  your MiSTer will reboot in 5 seconds to complete the installation."
+sleep 5
+echo "Rebooting now..."
+reboot

--- a/Install_SindenLightgunDriver.sh
+++ b/Install_SindenLightgunDriver.sh
@@ -42,7 +42,7 @@ if [ -f "/media/fat/Scripts/Install_SindenLightgunDriver.sh" ]; then
 fi
 
 # Print success message and inform the user about the reboot
-echo "Install Successful.  your MiSTer will reboot in 5 seconds to complete the installation."
+echo "Install Successful. Your MiSTer will reboot in 5 seconds to complete the installation."
 sleep 5
 echo "Rebooting now..."
 reboot

--- a/Install_SindenLightgunDriver.sh
+++ b/Install_SindenLightgunDriver.sh
@@ -21,7 +21,7 @@ cd $SINDEN_SCRIPTS_PATH
 # Inform the user to wait until the download is done
 echo "Please wait while the latest version is being downloaded..."
 # Download Sinden files on MiSTer using MrFusion 2.7
-wget -O main.zip https://github.com/Matt-Retrogamer/MiSTerSindenDriver/archive/refs/heads/main.zip
+wget -O main.zip https://github.com/MrLightgun/MiSTerSindenDriver/archive/refs/heads/main.zip
 
 # Inform the user to wait until the unzip is done
 echo "Please wait while the files are being unzipped..."

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ There are two options to install the `Install_SindenLightgunDriver.sh` script:
    ```
 1. Download the `Install_SindenLightgunDriver.sh` script directly to your MiSTer using `wget`:
    ```shell
-   wget https://raw.githubusercontent.com/Matt-Retrogamer/MiSTerSindenDriver/main/Install_SindenLightgunDriver.sh
+   wget https://raw.githubusercontent.com/MrLightgun/MiSTerSindenDriver/main/Install_SindenLightgunDriver.sh
    ```
 
 ### Execute the Installation Script

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ There are two options to install the `Install_SindenLightgunDriver.sh` script:
    ```
 1. Download the `Install_SindenLightgunDriver.sh` script directly to your MiSTer using `wget`:
    ```shell
-   wget https://raw.githubusercontent.com/MrLightgun/MiSTerSindenDriver/main/Install_SindenLightgunDriver.sh
+   wget https://raw.githubusercontent.com/Matt-Retrogamer/MiSTerSindenDriver/main/Install_SindenLightgunDriver.sh
    ```
 
 ### Execute the Installation Script

--- a/Setup_SindenLightgunDriver.sh
+++ b/Setup_SindenLightgunDriver.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Exit immediately if a command exits with a non-zero status
+set -e
+
 # Define the path for Sinden scripts
 SINDEN_SCRIPTS_PATH="/media/fat/Scripts/Sinden"
 

--- a/Setup_SindenLightgunDriver.sh
+++ b/Setup_SindenLightgunDriver.sh
@@ -16,12 +16,6 @@ chmod 755 /media/fat/_Console/*.rbf
 cd $SINDEN_SCRIPTS_PATH/MiSTerSindenDriver-main/StartupScripts
 cp -f *.sh /media/fat/Scripts
 
-# Copy lightgun driver
-cd $SINDEN_SCRIPTS_PATH/MiSTerSindenDriver-main/LightgunDriver
-mkdir -p /media/fat/SindenLightgun
-cp -f *.* /media/fat/SindenLightgun/
-cp -f LightgunDriver /media/fat/SindenLightgun/LightgunDriver
-
 # Copy tweaked kernel
 cd $SINDEN_SCRIPTS_PATH/MiSTerSindenDriver-main/Kernel/MiSTerFPGA/MrFusion2.7/
 cp -f /media/fat/linux/zImage_dtb /media/fat/linux/zImage_dtb_backup

--- a/Uninstall_SindenLightgunDriver.sh
+++ b/Uninstall_SindenLightgunDriver.sh
@@ -108,4 +108,10 @@ rm -f /media/fat/Scripts/SindenLightgunStart_LowResource.sh
 rm -f /media/fat/Scripts/SindenLightgunStart_MaxResource.sh
 rm -f /media/fat/Scripts/SindenLightgunStop.sh
 
+# Delete the first install Install_SindenLightgunDriver.sh file
+if [ -f "/media/fat/Scripts/Install_SindenLightgunDriver.sh" ]; then
+    echo "Deleting Install_SindenLightgunDriver.sh..."
+    rm -f /media/fat/Scripts/Install_SindenLightgunDriver.sh
+fi
+
 echo "MiSTerSindenDriver uninstallation completed. Please reboot your MiSTer."

--- a/Uninstall_SindenLightgunDriver.sh
+++ b/Uninstall_SindenLightgunDriver.sh
@@ -115,13 +115,3 @@ if [ -f "/media/fat/Scripts/Install_SindenLightgunDriver.sh" ]; then
 fi
 
 echo "MiSTerSindenDriver uninstallation completed. Please reboot your MiSTer."
-# Ask the user if they want to reboot the machine
-read -p "Uninstall Successful. Do you want to reboot the machine? (Y/N): " -n 1 -r </dev/tty
-echo    # move to a new line
-if [[ $REPLY =~ ^[Yy]$ ]]
-then
-    echo "Rebooting the machine..."
-    reboot
-else
-    echo "Reboot cancelled. Script completed successfully."
-fi

--- a/Uninstall_SindenLightgunDriver.sh
+++ b/Uninstall_SindenLightgunDriver.sh
@@ -115,3 +115,13 @@ if [ -f "/media/fat/Scripts/Install_SindenLightgunDriver.sh" ]; then
 fi
 
 echo "MiSTerSindenDriver uninstallation completed. Please reboot your MiSTer."
+# Ask the user if they want to reboot the machine
+read -p Uninstall Successful. Do you want to reboot the machine? (Y/N): " -n 1 -r
+echo    # move to a new line
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+    echo "Rebooting the machine..."
+    reboot
+else
+    echo "Reboot cancelled. Script completed successfully."
+fi

--- a/Uninstall_SindenLightgunDriver.sh
+++ b/Uninstall_SindenLightgunDriver.sh
@@ -116,7 +116,7 @@ fi
 
 echo "MiSTerSindenDriver uninstallation completed. Please reboot your MiSTer."
 # Ask the user if they want to reboot the machine
-read -p Uninstall Successful. Do you want to reboot the machine? (Y/N): " -n 1 -r
+read -p "Uninstall Successful. Do you want to reboot the machine? (Y/N): " -n 1 -r </dev/tty
 echo    # move to a new line
 if [[ $REPLY =~ ^[Yy]$ ]]
 then

--- a/Uninstall_SindenLightgunDriver.sh
+++ b/Uninstall_SindenLightgunDriver.sh
@@ -96,7 +96,7 @@ if [ -d "/media/fat/Lightgun" ]; then
     rm -rf /media/fat/Lightgun
 fi
 
-# Remove SindenLightgun folder
+# Remove deprecated SindenLightgun folder if it exists
 if [ -d "/media/fat/SindenLightgun" ]; then
     echo "/media/fat/SindenLightgun folder found. Deleting..."
     rm -rf /media/fat/SindenLightgun


### PR DESCRIPTION
* Initial install script in /media/fat/Scripts removed after successful install
* Initial install script in /media/fat/Scripts removed after successful uninstall (for people that installed with the old version)
* Improved error management (install scripts stop on errors)
* Automatic reboot of the MiSTer after 5 seconds when install is successful.
* unzip is now silent to keep the install output readable
* Removed temporary files (main.zip) and deprecated folders in the install process